### PR TITLE
Add emulator controls to sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pebble-vscode",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pebble-vscode",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "viewsWelcome": [
       {
         "view": "backgroundTreeView",
-        "contents": "[New Project](command:pebble.newProject)\n[Open Project](command:pebble.openProject)\nRun\n[Emulator](command:pebble.runEmulator)\n[Emulator with Logs](command:pebble.runEmulatorLogs)\n[Phone](command:pebble.runPhone)\n[Phone with Logs](command:pebble.runPhoneLogs)\nSettings\n[Change Emulator](command:pebble.setDefaultPlatform)\n[Change Phone](command:pebble.setPhoneIp)\nDownload\n[Download PBW](command:pebble.downloadPbw)\n[Download ZIP](command:pebble.downloadZip)\nDebug\n[Wipe Emulator](command:pebble.wipeEmulator)"
+        "contents": "[New Project](command:pebble.newProject)\n[Open Project](command:pebble.openProject)\nRun\n[Emulator](command:pebble.runEmulator)\n[Emulator with Logs](command:pebble.runEmulatorLogs)\n[Phone](command:pebble.runPhone)\n[Phone with Logs](command:pebble.runPhoneLogs)\nSettings\n[Open Emulator App Config](command:pebble.openEmulatorAppConfig)\n[Change Emulator](command:pebble.setDefaultPlatform)\n[Change Phone](command:pebble.setPhoneIp)\nDownload\n[Download PBW](command:pebble.downloadPbw)\n[Download ZIP](command:pebble.downloadZip)\nDebug\n[Wipe Emulator](command:pebble.wipeEmulator)"
       }
     ],
     "viewsContainers": {
@@ -115,6 +115,11 @@
       {
         "command": "pebble.runPhoneLogs",
         "title": "Run on Phone with Logs",
+        "category": "Pebble"
+      },
+      {
+        "command": "pebble.openEmulatorAppConfig",
+        "title": "Open emulator app configuration (Clay)",
         "category": "Pebble"
       },
       {
@@ -218,6 +223,10 @@
         },
         {
           "command": "pebble.runPhoneLogs",
+          "when": "pebbleProject"
+        },
+        {
+          "command": "pebble.openEmulatorAppConfig",
           "when": "pebbleProject"
         },
         {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "viewsWelcome": [
       {
         "view": "backgroundTreeView",
-        "contents": "[New Project](command:pebble.newProject)\n[Open Project](command:pebble.openProject)\nRun\n[Emulator](command:pebble.runEmulator)\n[Emulator with Logs](command:pebble.runEmulatorLogs)\n[Phone](command:pebble.runPhone)\n[Phone with Logs](command:pebble.runPhoneLogs)\nSettings\n[Open Emulator App Config](command:pebble.openEmulatorAppConfig)\n[Change Emulator](command:pebble.setDefaultPlatform)\n[Change Phone](command:pebble.setPhoneIp)\nDownload\n[Download PBW](command:pebble.downloadPbw)\n[Download ZIP](command:pebble.downloadZip)\nDebug\n[Wipe Emulator](command:pebble.wipeEmulator)"
+        "contents": "[New Project](command:pebble.newProject)\n[Open Project](command:pebble.openProject)\nRun\n[Emulator](command:pebble.runEmulator)\n[Emulator with Logs](command:pebble.runEmulatorLogs)\n[Phone](command:pebble.runPhone)\n[Phone with Logs](command:pebble.runPhoneLogs)\nSettings\n[Change Emulator](command:pebble.setDefaultPlatform)\n[Change Phone](command:pebble.setPhoneIp)\nDownload\n[Download PBW](command:pebble.downloadPbw)\n[Download ZIP](command:pebble.downloadZip)\nDebug\n[Wipe Emulator](command:pebble.wipeEmulator)"
       }
     ],
     "viewsContainers": {
@@ -72,6 +72,13 @@
           "name": "Pebble",
           "type": "tree",
           "contextualTitle": "Pebble Projects",
+          "icon": "$(file-code)"
+        },
+        {
+          "id": "pebble.testTreeView",
+          "name": "Pebble emulator actions",
+          "type": "tree",
+          "contextualTitle": "Pebble Emulator Actions",
           "icon": "$(file-code)"
         }
       ],
@@ -118,11 +125,6 @@
         "category": "Pebble"
       },
       {
-        "command": "pebble.openEmulatorAppConfig",
-        "title": "Open emulator app configuration (Clay)",
-        "category": "Pebble"
-      },
-      {
         "command": "pebble.setPhoneIp",
         "title": "Set Phone IP",
         "category": "Pebble"
@@ -155,6 +157,16 @@
       {
         "command": "pebble.downloadZip",
         "title": "Download ZIP",
+        "category": "Pebble"
+      },
+      {
+        "command": "pebble.openEmulatorAppConfig",
+        "title": "Open emulator app configuration",
+        "category": "Pebble"
+      },
+      {
+        "command": "pebble.emulatorBatterySetState",
+        "title": "Change Battery Level & Charging State",
         "category": "Pebble"
       }
     ],
@@ -226,15 +238,19 @@
           "when": "pebbleProject"
         },
         {
-          "command": "pebble.openEmulatorAppConfig",
-          "when": "pebbleProject"
-        },
-        {
           "command": "pebble.showSidebarPreview",
           "when": "pebbleProject"
         },
         {
           "command": "pebble.showEditorPreview",
+          "when": "pebbleProject"
+        },
+        {
+          "command": "pebble.openEmulatorAppConfig",
+          "when": "pebbleProject"
+        },
+        {
+          "command": "pebble.emulatorBatterySetState",
           "when": "pebbleProject"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -75,11 +75,12 @@
           "icon": "$(file-code)"
         },
         {
-          "id": "pebble.testTreeView",
+          "id": "pebble.emuActionsTreeView",
           "name": "Pebble emulator actions",
           "type": "tree",
           "contextualTitle": "Pebble Emulator Actions",
-          "icon": "$(file-code)"
+          "icon": "$(file-code)",
+          "initialSize": 0
         }
       ],
       "explorer": [
@@ -161,12 +162,32 @@
       },
       {
         "command": "pebble.openEmulatorAppConfig",
-        "title": "Open emulator app configuration",
+        "title": "Emulator - Open emulator app configuration in a browser",
         "category": "Pebble"
       },
       {
-        "command": "pebble.emulatorBatterySetState",
-        "title": "Change Battery Level & Charging State",
+        "command": "pebble.emuBatteryState",
+        "title": "Emulator - Change Battery Level & Charging State",
+        "category": "Pebble"
+      },
+      {
+        "command": "pebble.emuBluetoothState",
+        "title": "Emulator - Change Bluetooth Connection State",
+        "category": "Pebble"
+      },
+      {
+        "command": "pebble.emuTap",
+        "title": "Emulator - Emulates Tap",
+        "category": "Pebble"
+      },
+      {
+        "command": "pebble.emuTimeFormat",
+        "title": "Emulator - Sets Time Format (12h or 24h)",
+        "category": "Pebble"
+      },
+      {
+        "command": "pebble.emuTimelineQuickView",
+        "title": "Emulator - Change Timeline Quick View State",
         "category": "Pebble"
       }
     ],
@@ -250,7 +271,23 @@
           "when": "pebbleProject"
         },
         {
-          "command": "pebble.emulatorBatterySetState",
+          "command": "pebble.emuBatteryState",
+          "when": "pebbleProject"
+        },
+        {
+          "command": "pebble.emuBluetoothState",
+          "when": "pebbleProject"
+        },
+        {
+          "command": "pebble.emuTap",
+          "when": "pebbleProject"
+        },
+        {
+          "command": "pebble.emuTimeFormat",
+          "when": "pebbleProject"
+        },
+        {
+          "command": "pebble.emuTimelineQuickView",
           "when": "pebbleProject"
         }
       ]

--- a/src/emulatorControl.ts
+++ b/src/emulatorControl.ts
@@ -1,0 +1,99 @@
+import * as vscode from 'vscode';
+import { getWorkspacePath, getPebbleVersionInfo, isVersionBelow, upgradePebbleTool, isDevContainer } from './utils';
+import { getEmulatorPlatform } from './run';
+
+
+export async function openEmulatorAppConfig() {
+    console.log('openEmulatorAppConfig called');
+
+    const workspacePath = getWorkspacePath();
+    if (!workspacePath) {
+        vscode.window.showErrorMessage('No workspace folder is open. Please open a workspace folder and run the project.');
+        return;
+    }
+    
+    const platform = await getEmulatorPlatform();
+    if (!platform) {
+        console.log('No platform selected, returning early');
+        return;
+    }
+    console.log('Platform selected:', platform);
+
+    // Checking if the emulator is currently running : TODO ?
+    let terminal = vscode.window.terminals.find(t => t.name === `Pebble Run`);
+    if (!terminal) {
+        vscode.window.showErrorMessage('Please first run the project and keep the terminal open');
+        return;
+    }
+
+    if (isDevContainer()) {
+        vscode.window.showErrorMessage('Cannot display emulator app config inside DevContainer/Codespaces for the moment');
+        return;
+    }
+
+    terminal.show();
+    terminal.sendText('\x03'); // Send Ctrl+C
+
+    terminal.sendText(`pebble emu-app-config --emulator ${platform} --vnc`, true);
+}
+
+export async function emulatorBatterySetState() {
+    const platform = await getEmulatorPlatform();
+    if (!platform) {
+        console.log('No platform selected, returning early');
+        return;
+    }
+    console.log('Platform selected:', platform);
+
+    const batteryState = await vscode.window.showInputBox({
+        valueSelection: [0, 101],
+        placeHolder: 'Select a battery state',
+    });
+
+    if (!batteryState) {
+        return;
+    }
+
+    const chargingMap: {[key: string] : boolean } = {
+        'Yes': true,
+        'No': false
+    };
+
+    const chargingChoice = await vscode.window.showQuickPick(Object.keys(chargingMap), {
+        placeHolder: 'Is the battery charging?',
+        canPickMany: false,
+    });
+
+    if (!chargingChoice) {
+        return;
+    }
+
+    const charging = chargingMap[chargingChoice];
+
+    // Checking if the emulator is currently running : TODO ?
+    let terminal = vscode.window.terminals.find(t => t.name === `Pebble Run`);
+    if (!terminal) {
+        vscode.window.showErrorMessage('Please first run the project and keep the terminal open');
+        return;
+    }
+
+    terminal.show();
+
+    terminal.sendText(`pebble emu-battery --emulator ${platform} --vnc --percent ${batteryState} ${charging ? '--charging' : ''}`);
+}
+
+export async function emulatorBluetoothSetState() {
+
+}
+
+export async function emulatorAccelTapTrigger() {
+
+}
+
+export async function emulatorSetTimeFormat() {
+
+}
+
+export async function emulatorTimelineQuickViewSet() {
+
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,9 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { PebbleTreeProvider } from './pebbleTreeProvider';
-import { requestEmulatorPlatform, runOnEmulatorWithArgs, requestPhoneIp, runOnPhoneWithArgs, wipeEmulator, openEmulatorAppConfig } from './run';
+import { PebbleEmulationActionsTreeProvider } from './pebbleEmulationActionsTreeProvider';
+import { requestEmulatorPlatform, runOnEmulatorWithArgs, requestPhoneIp, runOnPhoneWithArgs, wipeEmulator } from './run';
+import { openEmulatorAppConfig, emulatorBatterySetState } from './emulatorControl';
 import { createProject, openProject } from './project';
 import { isPebbleProject } from './utils';
 
@@ -307,6 +309,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.registerWebviewViewProvider(PebblePreviewProvider.viewType, sidebarProvider)
 	);
 
+	vscode.window.createTreeView('pebble.testTreeView', {
+		treeDataProvider: new PebbleEmulationActionsTreeProvider()
+	});
+
 	// Helper function to show editor preview
 	async function showEditorPreview() {
 		if (!webviewPanel || webviewPanel.visible === false) {
@@ -377,10 +383,6 @@ export async function activate(context: vscode.ExtensionContext) {
 	const runWithLogs = vscode.commands.registerCommand('pebble.runEmulatorLogs', async () => {
 		createOrShowPreview();
 		runOnEmulatorWithArgs('--logs');
-	});
-
-	const openEmuAppConfig = vscode.commands.registerCommand('pebble.openEmulatorAppConfig', async () => {
-		openEmulatorAppConfig();
 	});
 
 	// Additional commands for controlling preview views
@@ -571,6 +573,14 @@ export async function activate(context: vscode.ExtensionContext) {
 				vscode.window.showErrorMessage(`Failed to create ZIP: ${error.message}`);
 			}
 		});
+	});
+
+	const openEmuAppConfig = vscode.commands.registerCommand('pebble.openEmulatorAppConfig', async () => {
+		openEmulatorAppConfig();
+	});
+
+	const emuBatteryState = vscode.commands.registerCommand('pebble.emuBatteryState', async () => {
+		emulatorBatterySetState();
 	});
 
 	const treeDataProvider = new PebbleTreeProvider();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import { PebbleTreeProvider } from './pebbleTreeProvider';
 import { PebbleEmulationActionsTreeProvider } from './pebbleEmulationActionsTreeProvider';
 import { requestEmulatorPlatform, runOnEmulatorWithArgs, requestPhoneIp, runOnPhoneWithArgs, wipeEmulator } from './run';
-import { openEmulatorAppConfig, emulatorBatterySetState } from './emulatorControl';
+import { openEmulatorAppConfig, emulatorBatterySetState, emulatorBluetoothSetState, emulatorAccelTapTrigger, emulatorSetTimeFormat, emulatorTimelineQuickViewSet } from './emulatorControl';
 import { createProject, openProject } from './project';
 import { isPebbleProject } from './utils';
 
@@ -309,10 +309,6 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.registerWebviewViewProvider(PebblePreviewProvider.viewType, sidebarProvider)
 	);
 
-	vscode.window.createTreeView('pebble.testTreeView', {
-		treeDataProvider: new PebbleEmulationActionsTreeProvider()
-	});
-
 	// Helper function to show editor preview
 	async function showEditorPreview() {
 		if (!webviewPanel || webviewPanel.visible === false) {
@@ -583,12 +579,33 @@ export async function activate(context: vscode.ExtensionContext) {
 		emulatorBatterySetState();
 	});
 
+	const emuBluetoothState = vscode.commands.registerCommand('pebble.emuBluetoothState', async () => {
+		emulatorBluetoothSetState();
+	});
+	
+	const emuAccelTap = vscode.commands.registerCommand('pebble.emuTap', async () => {
+		emulatorAccelTapTrigger();
+	});
+
+	const emuTimeFormat = vscode.commands.registerCommand('pebble.emuTimeFormat', async () => {
+		emulatorSetTimeFormat();
+	});
+
+	const emuTimelineQuickView = vscode.commands.registerCommand('pebble.emuTimelineQuickView', async () => {
+		emulatorTimelineQuickViewSet();
+	});
+
 	const treeDataProvider = new PebbleTreeProvider();
 	const treeView = vscode.window.createTreeView('backgroundTreeView', {
 		treeDataProvider: treeDataProvider
 	});
 
-	context.subscriptions.push(newProjectDisposable, openProjectDisposable, run, runWithLogs, openEmuAppConfig, setDefaultPlatform, runOnPhone, runOnPhoneWithLogs, setPhoneIp, wipeEmulatorCommand, downloadPbwCommand, downloadZipCommand, treeView, showSidebarPreview, showEditorPreviewCommand);
+	const emuActionsTreeDataProvider = new PebbleEmulationActionsTreeProvider();
+	const emuActionsTreeView = vscode.window.createTreeView('pebble.emuActionsTreeView', {
+		treeDataProvider: emuActionsTreeDataProvider
+	});
+
+	context.subscriptions.push(newProjectDisposable, openProjectDisposable, run, runWithLogs, setDefaultPlatform, runOnPhone, runOnPhoneWithLogs, setPhoneIp, wipeEmulatorCommand, downloadPbwCommand, downloadZipCommand, treeView, showSidebarPreview, showEditorPreviewCommand, emuActionsTreeView, openEmuAppConfig, emuBatteryState, emuBluetoothState, emuAccelTap, emuTimeFormat, emuTimelineQuickView);
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { PebbleTreeProvider } from './pebbleTreeProvider';
-import { requestEmulatorPlatform, runOnEmulatorWithArgs, requestPhoneIp, runOnPhoneWithArgs, wipeEmulator } from './run';
+import { requestEmulatorPlatform, runOnEmulatorWithArgs, requestPhoneIp, runOnPhoneWithArgs, wipeEmulator, openEmulatorAppConfig } from './run';
 import { createProject, openProject } from './project';
 import { isPebbleProject } from './utils';
 
@@ -379,6 +379,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		runOnEmulatorWithArgs('--logs');
 	});
 
+	const openEmuAppConfig = vscode.commands.registerCommand('pebble.openEmulatorAppConfig', async () => {
+		openEmulatorAppConfig();
+	});
+
 	// Additional commands for controlling preview views
 	const showSidebarPreview = vscode.commands.registerCommand('pebble.showSidebarPreview', () => {
 		sidebarProvider.show();
@@ -574,7 +578,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		treeDataProvider: treeDataProvider
 	});
 
-	context.subscriptions.push(newProjectDisposable, openProjectDisposable, run, runWithLogs, setDefaultPlatform, runOnPhone, runOnPhoneWithLogs, setPhoneIp, wipeEmulatorCommand, downloadPbwCommand, downloadZipCommand, treeView, showSidebarPreview, showEditorPreviewCommand);
+	context.subscriptions.push(newProjectDisposable, openProjectDisposable, run, runWithLogs, openEmuAppConfig, setDefaultPlatform, runOnPhone, runOnPhoneWithLogs, setPhoneIp, wipeEmulatorCommand, downloadPbwCommand, downloadZipCommand, treeView, showSidebarPreview, showEditorPreviewCommand);
 }
 
 export function deactivate() {}

--- a/src/pebbleEmulationActionsTreeProvider.ts
+++ b/src/pebbleEmulationActionsTreeProvider.ts
@@ -3,23 +3,24 @@ export class PebbleEmulationActionsTreeProvider implements vscode.TreeDataProvid
 
     actions: vscode.TreeItem[];
 
-    private createItem(label: string, commandId: string): vscode.TreeItem {
+    private createItem(label: string, commandId: string, themeIconId: string): vscode.TreeItem {
         let item = new vscode.TreeItem(label);
         item.command = {
             command: commandId,
             title: label
         };
+        item.iconPath = new vscode.ThemeIcon(themeIconId);
         return item; 
     }
 
     constructor() {
         this.actions = [
-            this.createItem('Display App Config', 'pebble.openEmulatorAppConfig'),
-            this.createItem('Change Battery Level & Charging State', 'pebble.emuBatteryState'),
-            this.createItem('Change Bluetooth Connection State', 'pebble.emuBluetoothState'),
-            this.createItem('Emulates Tap', 'pebble.emuTap'),
-            this.createItem('Sets Time Format (12h or 24h)', 'pebble.emuTimeFormat'),
-            this.createItem('Change Timeline Quick View State', 'pebble.emuTimelineQuickView'),
+            this.createItem('Open App Config in Browser', 'pebble.openEmulatorAppConfig', 'settings'),
+            this.createItem('Change Battery Level & Charging State', 'pebble.emuBatteryState', 'percentage'),
+            this.createItem('Change Bluetooth Connection State', 'pebble.emuBluetoothState', 'broadcast'),
+            this.createItem('Emulates Tap', 'pebble.emuTap', 'move'),
+            this.createItem('Sets Time Format (12h or 24h)', 'pebble.emuTimeFormat', 'calendar'),
+            this.createItem('Change Timeline Quick View State', 'pebble.emuTimelineQuickView', 'bell-dot'),
         ];
     }
 

--- a/src/pebbleEmulationActionsTreeProvider.ts
+++ b/src/pebbleEmulationActionsTreeProvider.ts
@@ -1,0 +1,52 @@
+import * as vscode from 'vscode';
+export class PebbleEmulationActionsTreeProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+
+    actions: vscode.TreeItem[];
+
+    private createItem(label: string, commandId: string): vscode.TreeItem {
+        let item = new vscode.TreeItem(label);
+        item.command = {
+            command: commandId,
+            title: label
+        };
+        return item; 
+    }
+
+    constructor() {
+        this.actions = [
+            this.createItem('Display App Config', 'pebble.openEmulatorAppConfig'),
+            this.createItem('Change Battery Level & Charging State', 'pebble.emuBatteryState'),
+            this.createItem('Change Bluetooth Connection State', 'pebble.emuBluetoothState'),
+            this.createItem('Emulates Tap', 'pebble.emuTap'),
+            this.createItem('Sets Time Format (12h or 24h)', 'pebble.emuTimeFormat'),
+            this.createItem('Change Timeline Quick View State', 'pebble.emuTimelineQuickView'),
+        ];
+    }
+
+    getChildren(element?: vscode.TreeItem | undefined): vscode.ProviderResult<vscode.TreeItem[]> {
+        if (!element) {
+            // Return the root items
+            return this.actions;
+        }
+        
+        // No children
+        return [];
+    }
+
+    getParent(element: vscode.TreeItem): vscode.ProviderResult<vscode.TreeItem> {
+        // Return the parent of the given element
+        // For this example, we assume all items are root items, so return undefined
+        return undefined;
+    }
+
+    getTreeItem(element: vscode.TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        // Return the TreeItem for the given element
+        return element;
+    }
+
+    resolveTreeItem(item: vscode.TreeItem, element: vscode.TreeItem, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TreeItem> {
+        // Resolve the TreeItem if needed
+        // For this example, we do not need to resolve anything
+        return item;
+    }
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -175,37 +175,3 @@ export async function wipeEmulator() {
         vscode.window.showInformationMessage('Emulator data wiped successfully.');
     });
 }
-
-export async function openEmulatorAppConfig() {
-    console.log('openEmulatorAppConfig called');
-
-    const workspacePath = getWorkspacePath();
-    if (!workspacePath) {
-        vscode.window.showErrorMessage('No workspace folder is open. Please open a workspace folder and run the project.');
-        return;
-    }
-    
-    const platform = await getEmulatorPlatform();
-    if (!platform) {
-        console.log('No platform selected, returning early');
-        return;
-    }
-    console.log('Platform selected:', platform);
-
-    // Checking if the emulator is currently running : TODO ?
-    let terminal = vscode.window.terminals.find(t => t.name === `Pebble Run`);
-    if (!terminal) {
-        vscode.window.showErrorMessage('Please first run the project and keep the terminal open');
-        return;
-    }
-
-    /* if (isDevContainer()) {
-        vscode.window.showErrorMessage('Cannot display emulator app config inside DevContainer/Codespaces');
-        return;
-    } */
-
-    terminal.show();
-    terminal.sendText('\x03'); // Send Ctrl+C
-
-    terminal.sendText(`pebble emu-app-config --emulator ${platform} --vnc`, true);
-}

--- a/src/run.ts
+++ b/src/run.ts
@@ -175,3 +175,37 @@ export async function wipeEmulator() {
         vscode.window.showInformationMessage('Emulator data wiped successfully.');
     });
 }
+
+export async function openEmulatorAppConfig() {
+    console.log('openEmulatorAppConfig called');
+
+    const workspacePath = getWorkspacePath();
+    if (!workspacePath) {
+        vscode.window.showErrorMessage('No workspace folder is open. Please open a workspace folder and run the project.');
+        return;
+    }
+    
+    const platform = await getEmulatorPlatform();
+    if (!platform) {
+        console.log('No platform selected, returning early');
+        return;
+    }
+    console.log('Platform selected:', platform);
+
+    // Checking if the emulator is currently running : TODO ?
+    let terminal = vscode.window.terminals.find(t => t.name === `Pebble Run`);
+    if (!terminal) {
+        vscode.window.showErrorMessage('Please first run the project and keep the terminal open');
+        return;
+    }
+
+    /* if (isDevContainer()) {
+        vscode.window.showErrorMessage('Cannot display emulator app config inside DevContainer/Codespaces');
+        return;
+    } */
+
+    terminal.show();
+    terminal.sendText('\x03'); // Send Ctrl+C
+
+    terminal.sendText(`pebble emu-app-config --emulator ${platform} --vnc`, true);
+}


### PR DESCRIPTION
This PR adds a 'TreeView' in the extension sidebar to quickly get access to emulator controls, such as :
- app configuration (disabled when in DevContainer / Codespace, not properly functioning)
- battery state
- bluetooth state
- accel-tap
- time format
- timeline quick view state

<img width="302" height="309" alt="pebble-emulator-actions" src="https://github.com/user-attachments/assets/69e3be5e-54f6-48d5-8344-3f905afe62fe" />


Closes #2 

- [x] WorksOnMyMachine
- [x] Test in DevContainer / Github Codespace

- [x] Making EmuAppConfig work in Github Codespace